### PR TITLE
jargon-databind: Fix node capacity handling

### DIFF
--- a/libraries/databind/src/main/java/org/fasterjson/jargon/databind/JsonTree.java
+++ b/libraries/databind/src/main/java/org/fasterjson/jargon/databind/JsonTree.java
@@ -152,13 +152,13 @@ public class JsonTree {
                 break;
             case START_ARRAY:
                 handleValue();
-                handleStartStruct(index, ContainerType.ARRAY);
-                set(index++, currentName, Type.ARRAY);
+                set(index, currentName, Type.ARRAY);
+                handleStartStruct(index++, ContainerType.ARRAY);
                 break;
             case START_OBJECT:
                 handleValue();
-                handleStartStruct(index, ContainerType.OBJECT);
-                set(index++, currentName, Type.OBJECT);
+                set(index, currentName, Type.OBJECT);
+                handleStartStruct(index++, ContainerType.OBJECT);
                 break;
             case VALUE_FALSE:
                 handleValue();
@@ -222,6 +222,9 @@ public class JsonTree {
             nodes[i] = new Node(i);
 
         nextSiblingIndexes = Arrays.copyOf(nextSiblingIndexes, newNodeCapacity);
+
+        for (int i = currentNodeCapacity; i < newNodeCapacity; i++)
+            nextSiblingIndexes[i] = i + 1;
     }
 
     private void handleStartStruct(final int index, final ContainerType containerType) throws JsonMappingException {

--- a/libraries/databind/src/test/java/org/fasterjson/jargon/databind/JsonTreeTest.java
+++ b/libraries/databind/src/test/java/org/fasterjson/jargon/databind/JsonTreeTest.java
@@ -376,7 +376,13 @@ class JsonTreeTest {
 
         parser.push(END_ARRAY);
 
-        tree.reset(parser);
+        root = tree.reset(parser);
+
+        assertTrue(root.isArray());
+        assertEquals(62, root.size());
+
+        for (int i = 0; i < 62; i++)
+            assertTrue(root.get(i).isNull());
     }
 
     @Test


### PR DESCRIPTION
Handle container nodes correctly when increasing node capacity and after increasing node capacity.