### PR TITLE
jargon-bench: Rename 'JsonTreeBench'

### DIFF
--- a/tests/bench/src/main/java/org/fasterjson/jargon/bench/jargon/databind/RandomCharAccessJsonTreeBench.java
+++ b/tests/bench/src/main/java/org/fasterjson/jargon/bench/jargon/databind/RandomCharAccessJsonTreeBench.java
@@ -25,7 +25,7 @@ import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Setup;
 
-public class JsonTreeBench extends Bench {
+public class RandomCharAccessJsonTreeBench extends Bench {
 
     private CharSequenceSource source;
 


### PR DESCRIPTION
Make it clear from the class name that it uses a random character access JSON parser.