### PR TITLE
Fix 'maven-shade-plugin' configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,9 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
           <version>3.3.0</version>
+          <configuration>
+            <createDependencyReducedPom>false</createDependencyReducedPom>
+          </configuration>
           <executions>
             <execution>
               <phase>package</phase>

--- a/tests/bench/pom.xml
+++ b/tests/bench/pom.xml
@@ -67,7 +67,12 @@
             <filter>
               <artifact>*:*</artifact>
               <excludes>
+                <exclude>LICENSE</exclude>
+                <exclude>META-INF/LICENSE</exclude>
+                <exclude>META-INF/NOTICE</exclude>
+                <exclude>META-INF/MANIFEST.MF</exclude>
                 <exclude>META-INF/versions/9/module-info.class</exclude>
+                <exclude>THIRD-PARTY</exclude>
                 <exclude>module-info.class</exclude>
               </excludes>
             </filter>


### PR DESCRIPTION
The plugin behavior has changed between the previously used version, 3.2.1, and the currently used version, 3.3.0.